### PR TITLE
NHibernate 4 support

### DIFF
--- a/NHibernate.SqlAzure.sln
+++ b/NHibernate.SqlAzure.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22310.1
+VisualStudioVersion = 14.0.22512.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHibernate.SqlAzure", "NHibernate.SqlAzure\NHibernate.SqlAzure.csproj", "{C51908DF-FAEA-4EAA-8F75-096346537C33}"
 EndProject
@@ -16,6 +16,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHibernate.SqlAzure.Tests", "NHibernate.SqlAzure.Tests\NHibernate.SqlAzure.Tests.csproj", "{887FD0A4-B8E0-4B3D-BF7E-4CC7090EB829}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHibernate4.SqlAzure", "NHibernate4.SqlAzure\NHibernate4.SqlAzure.csproj", "{BF649532-3E8A-4DC7-9F43-9AB25E475BF8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHibernate4.SqlAzure.Tests", "NHibernate4.SqlAzure.Tests\NHibernate4.SqlAzure.Tests.csproj", "{4864689E-5B40-4EA2-A797-63B2AEBFE5DC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -35,6 +37,10 @@ Global
 		{BF649532-3E8A-4DC7-9F43-9AB25E475BF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BF649532-3E8A-4DC7-9F43-9AB25E475BF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BF649532-3E8A-4DC7-9F43-9AB25E475BF8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4864689E-5B40-4EA2-A797-63B2AEBFE5DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4864689E-5B40-4EA2-A797-63B2AEBFE5DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4864689E-5B40-4EA2-A797-63B2AEBFE5DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4864689E-5B40-4EA2-A797-63B2AEBFE5DC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NHibernate.SqlAzure.sln
+++ b/NHibernate.SqlAzure.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 14
+VisualStudioVersion = 14.0.22310.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHibernate.SqlAzure", "NHibernate.SqlAzure\NHibernate.SqlAzure.csproj", "{C51908DF-FAEA-4EAA-8F75-096346537C33}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Files", "Solution Files", "{9C23CAA3-08A2-498A-AB98-F803AC42C49E}"
@@ -12,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Files", "Solution 
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHibernate.SqlAzure.Tests", "NHibernate.SqlAzure.Tests\NHibernate.SqlAzure.Tests.csproj", "{887FD0A4-B8E0-4B3D-BF7E-4CC7090EB829}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHibernate4.SqlAzure", "NHibernate4.SqlAzure\NHibernate4.SqlAzure.csproj", "{BF649532-3E8A-4DC7-9F43-9AB25E475BF8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +31,10 @@ Global
 		{887FD0A4-B8E0-4B3D-BF7E-4CC7090EB829}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{887FD0A4-B8E0-4B3D-BF7E-4CC7090EB829}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{887FD0A4-B8E0-4B3D-BF7E-4CC7090EB829}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF649532-3E8A-4DC7-9F43-9AB25E475BF8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF649532-3E8A-4DC7-9F43-9AB25E475BF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF649532-3E8A-4DC7-9F43-9AB25E475BF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF649532-3E8A-4DC7-9F43-9AB25E475BF8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NHibernate4.SqlAzure.Tests/App.config
+++ b/NHibernate4.SqlAzure.Tests/App.config
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<configuration>
+  <connectionStrings>
+    <add name="PooledDatabase" connectionString="Data Source=.\SQLEXPRESS;Integrated Security=True;Initial Catalog=NHibernateSqlAzureTests"/>
+    <add name="NonPooledDatabase" connectionString="Data Source=.\SQLEXPRESS;Integrated Security=True;Initial Catalog=NHibernateSqlAzureTests;Pooling=false"/>
+  </connectionStrings>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/NHibernate4.SqlAzure.Tests/NHibernate4.SqlAzure.Tests.csproj
+++ b/NHibernate4.SqlAzure.Tests/NHibernate4.SqlAzure.Tests.csproj
@@ -1,0 +1,95 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4864689E-5B40-4EA2-A797-63B2AEBFE5DC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NHibernate4.SqlAzure.Tests</RootNamespace>
+    <AssemblyName>NHibernate4.SqlAzure.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Accessibility" />
+    <Reference Include="FizzWare.NBuilder">
+      <HintPath>..\packages\NBuilder.3.0.1.1\lib\FizzWare.NBuilder.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentMigrator">
+      <HintPath>..\packages\FluentMigrator.1.1.2.1\lib\40\FluentMigrator.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentMigrator.Runner">
+      <HintPath>..\packages\FluentMigrator.Runner.1.1.1.26\lib\NET40\FluentMigrator.Runner.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentNHibernate, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\FluentNHibernate.2.0.1.0\lib\net40\FluentNHibernate.dll</HintPath>
+    </Reference>
+    <Reference Include="HibernatingRhinos.Profiler.Appender.v4.0">
+      <HintPath>..\packages\NHibernateProfiler.1.0.0.951\lib\Net40\HibernatingRhinos.Profiler.Appender.v4.0.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling">
+      <HintPath>..\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>
+    </Reference>
+    <Reference Include="NHibernate">
+      <HintPath>..\packages\NHibernate.4.0.2.4000\lib\net40\NHibernate.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.ServiceProcess" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\NHibernate.SqlAzure.Tests\**\*.cs" Exclude="..\NHibernate.SqlAzure.Tests\Properties\AssemblyInfo.cs;..\NHibernate.SqlAzure.Tests\obj\**;..\NHibernate.SqlAzure.Tests\bin\**;" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NHibernate4.SqlAzure\NHibernate4.SqlAzure.csproj">
+      <Project>{bf649532-3e8a-4dc7-9f43-9ab25e475bf8}</Project>
+      <Name>NHibernate4.SqlAzure</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/NHibernate4.SqlAzure.Tests/Properties/AssemblyInfo.cs
+++ b/NHibernate4.SqlAzure.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NHibernate4.SqlAzure.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NHibernate4.SqlAzure.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("4864689e-5b40-4ea2-a797-63b2aebfe5dc")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/NHibernate4.SqlAzure.Tests/packages.config
+++ b/NHibernate4.SqlAzure.Tests/packages.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net45" />
+  <package id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0.1304.1" targetFramework="net45" />
+  <package id="FluentMigrator" version="1.1.2.1" targetFramework="net45" />
+  <package id="FluentMigrator.Runner" version="1.1.1.26" targetFramework="net45" />
+  <package id="FluentNHibernate" version="2.0.1.0" targetFramework="net45" />
+  <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net45" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
+  <package id="NBuilder" version="3.0.1.1" targetFramework="net45" />
+  <package id="NHibernate" version="4.0.2.4000" targetFramework="net45" />
+  <package id="NHibernateProfiler" version="1.0.0.951" targetFramework="net45" />
+  <package id="NUnit" version="2.6.2" targetFramework="net45" />
+  <package id="WebActivator" version="1.4.4" targetFramework="net45" />
+</packages>

--- a/NHibernate4.SqlAzure/NHibernate4.SqlAzure.Standalone.nuspec
+++ b/NHibernate4.SqlAzure/NHibernate4.SqlAzure.Standalone.nuspec
@@ -1,0 +1,46 @@
+﻿<?xml version='1.0' encoding='UTF-8'?> 
+<package>
+  <metadata>
+    <id>
+       NHibernate4.SqlAzure.Standalone
+    </id>
+    <version>
+       2.0.0
+    </version>
+    <authors>
+       Robert Moore, Matthew Davies
+    </authors>
+    <description>
+      Provides an NHibernate driver that uses the Microsoft Transient Fault Handling library to allow for reliable SQL Azure connections.
+      Unlike NHibernate.SqlAzure, this library doesn't come with TransientFaultHandling IL-merged - instead it's a NuGet dependency.
+    </description>
+    <releaseNotes>
+      Please see https://github.com/MRCollective/NHibernate.SqlAzure/releases for release notes and https://github.com/MRCollective/NHibernate.SqlAzure/blob/master/BREAKING_CHANGES.md for any breaking changes.
+    </releaseNotes>
+    <projectUrl>
+      https://github.com/MRCollective/NHibernate.SqlAzure
+    </projectUrl>
+    <licenseUrl>
+      https://github.com/MRCollective/NHibernate.SqlAzure/blob/master/LICENSE
+    </licenseUrl>
+    <iconUrl>
+      https://raw.github.com/MRCollective/NHibernate.SqlAzure/master/logo.png
+    </iconUrl>
+    <tags>
+       nhibernate, azure, sql, sql azure, transient
+    </tags>
+    <language>
+       en-US 
+    </language>
+    <dependencies>
+      <dependency id="NHibernate" version="4.0.2.4000" />
+      <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0" />
+      <dependency id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0" />
+    </dependencies>
+  </metadata>
+  <files>
+     <file src="bin\Release\NHibernate.SqlAzure.dll" target="lib\NET45" />
+     <file src="bin\Release\NHibernate.SqlAzure.pdb" target="lib\NET45" />
+     <file src="bin\Release\NHibernate.SqlAzure.XML" target="lib\NET45" />
+  </files>
+</package>

--- a/NHibernate4.SqlAzure/NHibernate4.SqlAzure.csproj
+++ b/NHibernate4.SqlAzure/NHibernate4.SqlAzure.csproj
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{BF649532-3E8A-4DC7-9F43-9AB25E475BF8}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NHibernate.SqlAzure</RootNamespace>
+    <AssemblyName>NHibernate.SqlAzure</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\NHibernate.SqlAzure.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\NHibernate.SqlAzure.XML</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Iesi.Collections">
+      <HintPath>..\packages\Iesi.Collections.4.0.1.4000\lib\net40\Iesi.Collections.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling">
+      <HintPath>..\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data">
+      <HintPath>..\packages\EnterpriseLibrary.TransientFaultHandling.Data.6.0.1304.1\lib\NET45\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data.dll</HintPath>
+    </Reference>
+    <Reference Include="NHibernate">
+      <HintPath>..\packages\NHibernate.4.0.2.4000\lib\net40\NHibernate.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\NHibernate.SqlAzure\DefaultReliableSql2008ClientDriver.cs">
+      <Link>DefaultReliableSql2008ClientDriver.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure\ReliableAdoNetTransactionFactory.cs">
+      <Link>ReliableAdoNetTransactionFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure\ReliableAdoNetWithDistributedTransactionFactory.cs">
+      <Link>ReliableAdoNetWithDistributedTransactionFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure\ReliableAdoTransaction.cs">
+      <Link>ReliableAdoTransaction.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure\ReliableSql2008ClientDriver.cs">
+      <Link>ReliableSql2008ClientDriver.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure\ReliableSqlClientBatchingBatcher.cs">
+      <Link>ReliableSqlClientBatchingBatcher.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure\ReliableSqlClientBatchingBatcherFactory.cs">
+      <Link>ReliableSqlClientBatchingBatcherFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure\ReliableSqlCommand.cs">
+      <Link>ReliableSqlCommand.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure\ReliableSqlDbConnection.cs">
+      <Link>ReliableSqlDbConnection.cs</Link>
+      <SubType>component</SubType>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure\RetryStrategies\SqlAzureTransientErrorDetectionStrategy.cs">
+      <Link>RetryStrategies\SqlAzureTransientErrorDetectionStrategy.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure\RetryStrategies\SqlAzureTransientErrorDetectionStrategyWithTimeouts.cs">
+      <Link>RetryStrategies\SqlAzureTransientErrorDetectionStrategyWithTimeouts.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure\SqlAzureClientDriver.cs">
+      <Link>SqlAzureClientDriver.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure\SqlAzureClientDriverWithTimeoutRetries.cs">
+      <Link>SqlAzureClientDriverWithTimeoutRetries.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="NHibernate4.SqlAzure.nuspec">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="NHibernate4.SqlAzure.Standalone.nuspec">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>mkdir "$(TargetDir)Combined"
+"$(ProjectDir)..\packages\ilmerge.2.13.0307\ILMerge.exe" /v4 /target:library "$(TargetPath)" "$(TargetDir)Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll" "$(TargetDir)Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data.dll" /out:"$(TargetDir)Combined\NHibernate.SqlAzure.dll"
+copy "$(TargetDir)NHibernate.SqlAzure.XML" "$(TargetDir)Combined\NHibernate.SqlAzure.XML"</PostBuildEvent>
+  </PropertyGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/NHibernate4.SqlAzure/NHibernate4.SqlAzure.csproj
+++ b/NHibernate4.SqlAzure/NHibernate4.SqlAzure.csproj
@@ -53,46 +53,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\NHibernate.SqlAzure\DefaultReliableSql2008ClientDriver.cs">
-      <Link>DefaultReliableSql2008ClientDriver.cs</Link>
-    </Compile>
-    <Compile Include="..\NHibernate.SqlAzure\ReliableAdoNetTransactionFactory.cs">
-      <Link>ReliableAdoNetTransactionFactory.cs</Link>
-    </Compile>
-    <Compile Include="..\NHibernate.SqlAzure\ReliableAdoNetWithDistributedTransactionFactory.cs">
-      <Link>ReliableAdoNetWithDistributedTransactionFactory.cs</Link>
-    </Compile>
-    <Compile Include="..\NHibernate.SqlAzure\ReliableAdoTransaction.cs">
-      <Link>ReliableAdoTransaction.cs</Link>
-    </Compile>
-    <Compile Include="..\NHibernate.SqlAzure\ReliableSql2008ClientDriver.cs">
-      <Link>ReliableSql2008ClientDriver.cs</Link>
-    </Compile>
-    <Compile Include="..\NHibernate.SqlAzure\ReliableSqlClientBatchingBatcher.cs">
-      <Link>ReliableSqlClientBatchingBatcher.cs</Link>
-    </Compile>
-    <Compile Include="..\NHibernate.SqlAzure\ReliableSqlClientBatchingBatcherFactory.cs">
-      <Link>ReliableSqlClientBatchingBatcherFactory.cs</Link>
-    </Compile>
-    <Compile Include="..\NHibernate.SqlAzure\ReliableSqlCommand.cs">
-      <Link>ReliableSqlCommand.cs</Link>
-    </Compile>
-    <Compile Include="..\NHibernate.SqlAzure\ReliableSqlDbConnection.cs">
-      <Link>ReliableSqlDbConnection.cs</Link>
-      <SubType>component</SubType>
-    </Compile>
-    <Compile Include="..\NHibernate.SqlAzure\RetryStrategies\SqlAzureTransientErrorDetectionStrategy.cs">
-      <Link>RetryStrategies\SqlAzureTransientErrorDetectionStrategy.cs</Link>
-    </Compile>
-    <Compile Include="..\NHibernate.SqlAzure\RetryStrategies\SqlAzureTransientErrorDetectionStrategyWithTimeouts.cs">
-      <Link>RetryStrategies\SqlAzureTransientErrorDetectionStrategyWithTimeouts.cs</Link>
-    </Compile>
-    <Compile Include="..\NHibernate.SqlAzure\SqlAzureClientDriver.cs">
-      <Link>SqlAzureClientDriver.cs</Link>
-    </Compile>
-    <Compile Include="..\NHibernate.SqlAzure\SqlAzureClientDriverWithTimeoutRetries.cs">
-      <Link>SqlAzureClientDriverWithTimeoutRetries.cs</Link>
-    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure\**\*.cs" Exclude="..\NHibernate.SqlAzure\Properties\AssemblyInfo.cs;..\NHibernate.SqlAzure\obj\**;..\NHibernate.SqlAzure\bin\**;"/>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/NHibernate4.SqlAzure/NHibernate4.SqlAzure.nuspec
+++ b/NHibernate4.SqlAzure/NHibernate4.SqlAzure.nuspec
@@ -1,0 +1,44 @@
+﻿<?xml version='1.0' encoding='UTF-8'?> 
+<package>
+  <metadata>
+    <id>
+       NHibernate4.SqlAzure
+    </id>
+    <version>
+       2.0.0
+    </version>
+    <authors>
+       Robert Moore, Matthew Davies
+    </authors>
+    <description>
+      Provides an NHibernate driver that uses the Microsoft Transient Fault Handling library to allow for reliable SQL Azure connections.
+      This package has the Microsoft Transient Fault Handling library IL-merged into it; for a version that doesn't see the NHibernate.SqlAzure.Standalone package.
+    </description>
+    <releaseNotes>
+      Please see https://github.com/MRCollective/NHibernate.SqlAzure/releases for release notes and https://github.com/MRCollective/NHibernate.SqlAzure/blob/master/BREAKING_CHANGES.md for any breaking changes.
+    </releaseNotes>
+    <projectUrl>
+      https://github.com/MRCollective/NHibernate.SqlAzure
+    </projectUrl>
+    <licenseUrl>
+      https://github.com/MRCollective/NHibernate.SqlAzure/blob/master/LICENSE
+    </licenseUrl>
+    <iconUrl>
+      https://raw.github.com/MRCollective/NHibernate.SqlAzure/master/logo.png
+    </iconUrl>
+    <tags>
+       nhibernate, azure, sql, sql azure, transient
+    </tags>
+    <language>
+       en-US 
+    </language>
+    <dependencies>
+      <dependency id="NHibernate" version="4.0.2.4000" />
+    </dependencies>
+  </metadata>
+  <files>
+     <file src="bin\Release\Combined\NHibernate.SqlAzure.dll" target="lib\NET45" />
+     <file src="bin\Release\Combined\NHibernate.SqlAzure.pdb" target="lib\NET45" />
+     <file src="bin\Release\Combined\NHibernate.SqlAzure.XML" target="lib\NET45" />
+  </files>
+</package>

--- a/NHibernate4.SqlAzure/Properties/AssemblyInfo.cs
+++ b/NHibernate4.SqlAzure/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NHibernate4.SqlAzure")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NHibernate4.SqlAzure")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("bf649532-3e8a-4dc7-9f43-9ab25e475bf8")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/NHibernate4.SqlAzure/packages.config
+++ b/NHibernate4.SqlAzure/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net45" />
+  <package id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0.1304.1" targetFramework="net45" />
+  <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net45" />
+  <package id="ilmerge" version="2.13.0307" targetFramework="net45" />
+  <package id="NHibernate" version="4.0.2.4000" targetFramework="net45" />
+</packages>

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -2,5 +2,6 @@
 <repositories>
   <repository path="..\NHibernate.SqlAzure.Tests\packages.config" />
   <repository path="..\NHibernate.SqlAzure\packages.config" />
+  <repository path="..\NHibernate4.SqlAzure.Tests\packages.config" />
   <repository path="..\NHibernate4.SqlAzure\packages.config" />
 </repositories>

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -2,4 +2,5 @@
 <repositories>
   <repository path="..\NHibernate.SqlAzure.Tests\packages.config" />
   <repository path="..\NHibernate.SqlAzure\packages.config" />
+  <repository path="..\NHibernate4.SqlAzure\packages.config" />
 </repositories>


### PR DESCRIPTION
I lazily built a version of this library from source against NHibernate 4 in November. All the tests seem to pass, and it's been running in a production site for two months now without any issues that I can tell, so I thought it'd be appropriate to create a version that could be packaged to NuGet. 

I created a project that builds against NHibernate 4 and contains nuspec files for NHibernate4.SqlAzure. It could just as well be a major version bump, but I wasn't sure if that was the right way to go, so... your call, I guess. :)