### PR TITLE
Adding more transient error codes as per MSDN docs

### DIFF
--- a/NHibernate.SqlAzure/RetryStrategies/SqlAzureTransientErrorDetectionStrategy.cs
+++ b/NHibernate.SqlAzure/RetryStrategies/SqlAzureTransientErrorDetectionStrategy.cs
@@ -11,7 +11,15 @@ namespace NHibernate.SqlAzure.RetryStrategies
     /// </summary>
     public class SqlAzureTransientErrorDetectionStrategy : ITransientErrorDetectionStrategy
     {
+        // From Enterprise Library 6 changelog (see https://entlib.codeplex.com/wikipage?title=EntLib6ReleaseNotes):
+        // Error code 40540 from SQL Database added as a transient error (see http://msdn.microsoft.com/en-us/library/ff394106.aspx#bkmk_throt_errors).
+        // Added error codes 10928 and 10929 from SQL Database as transient errors (see http://blogs.msdn.com/b/psssql/archive/2012/10/31/worker-thread-governance-coming-to-azure-sql-database.aspx).
+        // Added error codes 4060, 40197, 40501, 40613 from MSDN documentation (see https://azure.microsoft.com/en-us/documentation/articles/sql-database-develop-error-messages/)
+
+        private readonly int[] _errorNumbers = new int[] { 40540, 10928, 10929, 4060, 40197, 40501, 40613 };
+
         private readonly SqlDatabaseTransientErrorDetectionStrategy _entLibStrategy = new SqlDatabaseTransientErrorDetectionStrategy();
+
         public virtual bool IsTransient(Exception ex)
         {
             return IsTransientAzureException(ex);
@@ -29,13 +37,9 @@ namespace NHibernate.SqlAzure.RetryStrategies
 
         private bool IsNewTransientError(Exception ex)
         {
-            // From Enterprise Library 6 changelog (see https://entlib.codeplex.com/wikipage?title=EntLib6ReleaseNotes):
-            // Error code 40540 from SQL Database added as a transient error (see http://msdn.microsoft.com/en-us/library/ff394106.aspx#bkmk_throt_errors).
-            // Added error codes 10928 and 10929 from SQL Database as transient errors (see http://blogs.msdn.com/b/psssql/archive/2012/10/31/worker-thread-governance-coming-to-azure-sql-database.aspx).
-
             SqlException sqlException;
             return (sqlException = ex as SqlException) != null
-                   && sqlException.Errors.Cast<SqlError>().Any(error => error.Number == 40540 || error.Number == 10928 || error.Number == 10929);
+                   && sqlException.Errors.Cast<SqlError>().Any(error => _errorNumbers.Contains(error.Number));
         }
     }
 }


### PR DESCRIPTION
According to updated MSDN documentation, I've added a few more error codes that are considered MS/Azure SQL transient errors.

Also refactored the error check to use an array of error codes to simplify the code.

for reference see https://azure.microsoft.com/en-us/documentation/articles/sql-database-develop-error-messages/