### PR TITLE
Update to include NHibernate 5 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ _ReSharper*
 packages
 *.ncrunch*
 *.DotSettings
+/.vs/NHibernate.SqlAzure/v15/Server/sqlite3

--- a/NHibernate.SqlAzure.sln
+++ b/NHibernate.SqlAzure.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.22512.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHibernate.SqlAzure", "NHibernate.SqlAzure\NHibernate.SqlAzure.csproj", "{C51908DF-FAEA-4EAA-8F75-096346537C33}"
 EndProject
@@ -18,6 +18,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHibernate4.SqlAzure", "NHibernate4.SqlAzure\NHibernate4.SqlAzure.csproj", "{BF649532-3E8A-4DC7-9F43-9AB25E475BF8}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHibernate4.SqlAzure.Tests", "NHibernate4.SqlAzure.Tests\NHibernate4.SqlAzure.Tests.csproj", "{4864689E-5B40-4EA2-A797-63B2AEBFE5DC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHibernate5.SqlAzure", "NHibernate5.SqlAzure\NHibernate5.SqlAzure.csproj", "{895B6F59-B5BE-4796-847D-C3FF2C7EED66}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -41,11 +43,16 @@ Global
 		{4864689E-5B40-4EA2-A797-63B2AEBFE5DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4864689E-5B40-4EA2-A797-63B2AEBFE5DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4864689E-5B40-4EA2-A797-63B2AEBFE5DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{895B6F59-B5BE-4796-847D-C3FF2C7EED66}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{895B6F59-B5BE-4796-847D-C3FF2C7EED66}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{895B6F59-B5BE-4796-847D-C3FF2C7EED66}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{895B6F59-B5BE-4796-847D-C3FF2C7EED66}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		EnterpriseLibraryConfigurationToolBinariesPathV6 = packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8;packages\EnterpriseLibrary.TransientFaultHandling.Data.6.0.1304.1\lib\NET45
+		SolutionGuid = {A2187D5F-03DE-4CF8-A458-16694FC9F9D6}
 	EndGlobalSection
 EndGlobal

--- a/NHibernate.SqlAzure.sln
+++ b/NHibernate.SqlAzure.sln
@@ -21,6 +21,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHibernate4.SqlAzure.Tests"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHibernate5.SqlAzure", "NHibernate5.SqlAzure\NHibernate5.SqlAzure.csproj", "{895B6F59-B5BE-4796-847D-C3FF2C7EED66}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHibernate5.SqlAzure.Tests", "NHibernate5.SqlAzure.Tests\NHibernate5.SqlAzure.Tests.csproj", "{BF71D707-D321-40DB-97CB-3A3A02F345D5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -47,12 +49,16 @@ Global
 		{895B6F59-B5BE-4796-847D-C3FF2C7EED66}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{895B6F59-B5BE-4796-847D-C3FF2C7EED66}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{895B6F59-B5BE-4796-847D-C3FF2C7EED66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF71D707-D321-40DB-97CB-3A3A02F345D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF71D707-D321-40DB-97CB-3A3A02F345D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF71D707-D321-40DB-97CB-3A3A02F345D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF71D707-D321-40DB-97CB-3A3A02F345D5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		EnterpriseLibraryConfigurationToolBinariesPathV6 = packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8;packages\EnterpriseLibrary.TransientFaultHandling.Data.6.0.1304.1\lib\NET45
 		SolutionGuid = {A2187D5F-03DE-4CF8-A458-16694FC9F9D6}
+		EnterpriseLibraryConfigurationToolBinariesPathV6 = packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8;packages\EnterpriseLibrary.TransientFaultHandling.Data.6.0.1304.1\lib\NET45
 	EndGlobalSection
 EndGlobal

--- a/NHibernate5.SqlAzure.Tests/App.Release.config
+++ b/NHibernate5.SqlAzure.Tests/App.Release.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <appSettings>
+    <add key="SqlServerServiceName" value="MSSQL$SQL2008R2SP2" xdt:Locator="Match(key)" xdt:Transform="SetAttributes" />
+  </appSettings>
+  <connectionStrings>
+    <add name="PooledDatabase" connectionString="Server=(local)\SQL2008R2SP2;Database=master;User ID=sa;Password=Password12!;Initial Catalog=NHibernateSqlAzureTests" xdt:Locator="Match(name)" xdt:Transform="SetAttributes" />
+    <add name="NonPooledDatabase" connectionString="Server=(local)\SQL2008R2SP2;Database=master;User ID=sa;Password=Password12!;Initial Catalog=NHibernateSqlAzureTests;Pooling=false" xdt:Locator="Match(name)" xdt:Transform="SetAttributes" />
+  </connectionStrings>
+</configuration>

--- a/NHibernate5.SqlAzure.Tests/App.config
+++ b/NHibernate5.SqlAzure.Tests/App.config
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <connectionStrings>
+    <add name="PooledDatabase" connectionString="Data Source=.\SQLEXPRESS;Integrated Security=True;Initial Catalog=NHibernateSqlAzureTests" />
+    <add name="NonPooledDatabase" connectionString="Data Source=.\SQLEXPRESS;Integrated Security=True;Initial Catalog=NHibernateSqlAzureTests;Pooling=false" />
+  </connectionStrings>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="FluentMigrator" publicKeyToken="aacfc7de5acabf05" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.2.1" newVersion="1.1.2.1" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/NHibernate5.SqlAzure.Tests/App.config
+++ b/NHibernate5.SqlAzure.Tests/App.config
@@ -1,19 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <appSettings>
+    <add key="SqlServerServiceName" value="MSSQL$SQLEXPRESS" />
+  </appSettings>
   <connectionStrings>
     <add name="PooledDatabase" connectionString="Data Source=.\SQLEXPRESS;Integrated Security=True;Initial Catalog=NHibernateSqlAzureTests" />
     <add name="NonPooledDatabase" connectionString="Data Source=.\SQLEXPRESS;Integrated Security=True;Initial Catalog=NHibernateSqlAzureTests;Pooling=false" />
   </connectionStrings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+  </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="FluentMigrator" publicKeyToken="aacfc7de5acabf05" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.2.1" newVersion="1.1.2.1" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/NHibernate5.SqlAzure.Tests/App_Start/NHibernateProfilerBootstrapper.cs
+++ b/NHibernate5.SqlAzure.Tests/App_Start/NHibernateProfilerBootstrapper.cs
@@ -1,0 +1,25 @@
+using HibernatingRhinos.Profiler.Appender.NHibernate;
+
+// If you're using .NET Core please remove this line and call NHibernateProfiler.Initialize(); on the very beginning of your application.
+[assembly: WebActivatorEx.PreApplicationStartMethod(typeof(NHibernate5.SqlAzure.Tests.App_Start.NHibernateProfilerBootstrapper), "PreStart")]
+namespace NHibernate5.SqlAzure.Tests.App_Start
+{
+	public static class NHibernateProfilerBootstrapper
+	{
+		public static void PreStart()
+		{
+			// Initialize the profiler
+			NHibernateProfiler.Initialize();
+			
+			// You can also use the profiler in an offline manner.
+			// This will generate a file with a snapshot of all the NHibernate activity in the application,
+			// which you can use for later analysis by loading the file into the profiler.
+			// var filename = @"c:\profiler-log";
+			// NHibernateProfiler.InitializeOfflineProfiling(filename);
+
+			// You can use the following for production profiling.
+			// NHibernateProfiler.InitializeForProduction(11234, "A strong password like: ze38r/b2ulve2HLQB8NK5AYig");
+		}
+	}
+}
+

--- a/NHibernate5.SqlAzure.Tests/App_Start/NHibernateProfilerBootstrapper.vb
+++ b/NHibernate5.SqlAzure.Tests/App_Start/NHibernateProfilerBootstrapper.vb
@@ -1,0 +1,22 @@
+Imports HibernatingRhinos.Profiler.Appender.NHibernate
+
+' If you're using .NET Core please remove this line and call NHibernateProfiler.Initialize() on the very beginning of your application.
+<assembly: WebActivatorEx.PreApplicationStartMethod(GetType(Global.NHibernate5.SqlAzure.Tests.App_Start.NHibernateProfilerBootstrapper), "PreStart")>
+Namespace App_Start
+	Public Class NHibernateProfilerBootstrapper
+		Public Shared Sub PreStart()
+			' Initialize the profiler
+			NHibernateProfiler.Initialize()
+
+			' You can also use the profiler in an offline manner.
+			' This will generate a file with a snapshot of all the NHibernate activity in the application,
+			' which you can use for later analysis by loading the file into the profiler.
+			' Dim FileName as String = @"c:\profiler-log";
+			' NHibernateProfiler.InitializeOfflineProfiling(FileName)
+
+			' You can use the following for production profiling.
+			' NHibernateProfiler.InitializeForProduction(11234, "A strong password like: ze38r/b2ulve2HLQB8NK5AYig");
+		End Sub
+	End Class
+End Namespace
+

--- a/NHibernate5.SqlAzure.Tests/NHibernate5.SqlAzure.Tests.csproj
+++ b/NHibernate5.SqlAzure.Tests/NHibernate5.SqlAzure.Tests.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -64,12 +63,6 @@
     </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\EnterpriseLibrary.TransientFaultHandling.Data.6.0.1304.1\lib\NET45\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
@@ -163,12 +156,4 @@
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets'))" />
-  </Target>
-  <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" />
 </Project>

--- a/NHibernate5.SqlAzure.Tests/NHibernate5.SqlAzure.Tests.csproj
+++ b/NHibernate5.SqlAzure.Tests/NHibernate5.SqlAzure.Tests.csproj
@@ -1,0 +1,174 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{BF71D707-D321-40DB-97CB-3A3A02F345D5}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NHibernate5.SqlAzure.Tests</RootNamespace>
+    <AssemblyName>NHibernate5.SqlAzure.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f, processorArchitecture=MSIL">
+      <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="FizzWare.NBuilder, Version=3.0.1.0, Culture=neutral, PublicKeyToken=5651b03e12e42c12, processorArchitecture=MSIL">
+      <HintPath>..\packages\NBuilder.3.0.1.1\lib\FizzWare.NBuilder.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentMigrator, Version=1.1.2.1, Culture=neutral, PublicKeyToken=aacfc7de5acabf05, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentMigrator.1.1.2.1\lib\40\FluentMigrator.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentMigrator.Runner, Version=1.1.2.1, Culture=neutral, PublicKeyToken=aacfc7de5acabf05, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentMigrator.Runner.1.1.1.26\lib\NET40\FluentMigrator.Runner.dll</HintPath>
+    </Reference>
+    <Reference Include="FluentNHibernate, Version=2.0.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentNHibernate.2.0.3.0\lib\net40\FluentNHibernate.dll</HintPath>
+    </Reference>
+    <Reference Include="HibernatingRhinos.Profiler.Appender, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0774796e73ebf640, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernateProfiler.4.0.4049\lib\net46\HibernatingRhinos.Profiler.Appender.dll</HintPath>
+    </Reference>
+    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Iesi.Collections.4.0.2\lib\net461\Iesi.Collections.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\EnterpriseLibrary.TransientFaultHandling.Data.6.0.1304.1\lib\NET45\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
+    </Reference>
+    <Reference Include="NHibernate, Version=5.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.5.0.3\lib\net461\NHibernate.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="Remotion.Linq.EagerFetching, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Remotion.Linq.EagerFetching.2.1.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.ServiceProcess" />
+    <Reference Include="System.Transactions" />
+    <Reference Include="WebActivator, Version=1.4.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\WebActivator.1.4.4\lib\net40\WebActivator.dll</HintPath>
+    </Reference>
+    <Reference Include="WebActivatorEx, Version=2.0.0.0, Culture=neutral, PublicKeyToken=7b26dc2a43f6a0d4, processorArchitecture=MSIL">
+      <HintPath>..\packages\WebActivatorEx.2.0.5\lib\net40\WebActivatorEx.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\NHibernate.SqlAzure.Tests\Config\FluentRunner.cs">
+      <Link>FluentRunner.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure.Tests\Config\LocalTestingReliableSql2008ClientDriver.cs">
+      <Link>LocalTestingReliableSql2008ClientDriver.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure.Tests\Config\NHibernateConfiguration.cs">
+      <Link>NHibernateConfiguration.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure.Tests\Config\NHibernateTestBase.cs">
+      <Link>NHibernateTestBase.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure.Tests\Config\SqlExpressTransientErrorDetectionStrategy.cs">
+      <Link>SqlExpressTransientErrorDetectionStrategy.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure.Tests\ConnectionTests.cs">
+      <Link>ConnectionTests.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure.Tests\Entities\User.cs">
+      <Link>User.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure.Tests\Entities\UserProperty.cs">
+      <Link>UserProperty.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure.Tests\Migrations\20120801141148_CreateUserTable.cs">
+      <Link>20120801141148_CreateUserTable.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure.Tests\Migrations\20120809201500_CreateUserPropertyTable.cs">
+      <Link>20120809201500_CreateUserPropertyTable.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure.Tests\SqlClientDriverTests.cs">
+      <Link>SqlClientDriverTests.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure.Tests\TransientErrorDetectionTests.cs">
+      <Link>TransientErrorDetectionTests.cs</Link>
+    </Compile>
+    <Compile Include="App_Start\NHibernateProfilerBootstrapper.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NHibernate5.SqlAzure\NHibernate5.SqlAzure.csproj">
+      <Project>{895b6f59-b5be-4796-847d-c3ff2c7eed66}</Project>
+      <Name>NHibernate5.SqlAzure</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="App_Start\NHibernateProfilerBootstrapper.vb" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.1.2.0\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/NHibernate5.SqlAzure.Tests/NHibernate5.SqlAzure.Tests.csproj
+++ b/NHibernate5.SqlAzure.Tests/NHibernate5.SqlAzure.Tests.csproj
@@ -140,6 +140,11 @@
   <ItemGroup>
     <None Include="App.config">
       <SubType>Designer</SubType>
+      <TransformOnBuild>true</TransformOnBuild>
+    </None>
+    <None Include="App.Release.config">
+      <DependentUpon>App.config</DependentUpon>
+      <IsTransformFile>True</IsTransformFile>
     </None>
     <None Include="packages.config">
       <SubType>Designer</SubType>
@@ -156,4 +161,11 @@
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.VisualStudio.SlowCheetah.3.0.61\build\Microsoft.VisualStudio.SlowCheetah.targets" Condition="Exists('..\packages\Microsoft.VisualStudio.SlowCheetah.3.0.61\build\Microsoft.VisualStudio.SlowCheetah.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.VisualStudio.SlowCheetah.3.0.61\build\Microsoft.VisualStudio.SlowCheetah.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VisualStudio.SlowCheetah.3.0.61\build\Microsoft.VisualStudio.SlowCheetah.targets'))" />
+  </Target>
 </Project>

--- a/NHibernate5.SqlAzure.Tests/Properties/AssemblyInfo.cs
+++ b/NHibernate5.SqlAzure.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("NHibernate5.SqlAzure.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NHibernate5.SqlAzure.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("bf71d707-d321-40db-97cb-3a3a02f345d5")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/NHibernate5.SqlAzure.Tests/packages.config
+++ b/NHibernate5.SqlAzure.Tests/packages.config
@@ -7,6 +7,7 @@
   <package id="FluentMigrator.Runner" version="1.1.1.26" targetFramework="net461" />
   <package id="FluentNHibernate" version="2.0.3.0" targetFramework="net461" />
   <package id="Iesi.Collections" version="4.0.2" targetFramework="net461" />
+  <package id="Microsoft.VisualStudio.SlowCheetah" version="3.0.61" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="NBuilder" version="3.0.1.1" targetFramework="net461" />
   <package id="NHibernate" version="5.0.3" targetFramework="net461" />

--- a/NHibernate5.SqlAzure.Tests/packages.config
+++ b/NHibernate5.SqlAzure.Tests/packages.config
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
+  <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net461" />
+  <package id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0.1304.1" targetFramework="net461" />
+  <package id="FluentMigrator" version="1.1.2.1" targetFramework="net461" />
+  <package id="FluentMigrator.Runner" version="1.1.1.26" targetFramework="net461" />
+  <package id="FluentNHibernate" version="2.0.3.0" targetFramework="net461" />
+  <package id="Iesi.Collections" version="4.0.2" targetFramework="net461" />
+  <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
+  <package id="NBuilder" version="3.0.1.1" targetFramework="net461" />
+  <package id="NHibernate" version="5.0.3" targetFramework="net461" />
+  <package id="NHibernateProfiler" version="4.0.4049" targetFramework="net461" />
+  <package id="NUnit" version="2.6.2" targetFramework="net461" />
+  <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
+  <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net461" />
+  <package id="WebActivator" version="1.4.4" targetFramework="net461" />
+  <package id="WebActivatorEx" version="2.0.5" targetFramework="net461" />
+</packages>

--- a/NHibernate5.SqlAzure/NHibernate5.SqlAzure.Standalone.nuspec
+++ b/NHibernate5.SqlAzure/NHibernate5.SqlAzure.Standalone.nuspec
@@ -1,0 +1,47 @@
+﻿<?xml version='1.0' encoding='UTF-8'?> 
+<package>
+  <metadata>
+    <id>
+       NHibernate4.SqlAzure.Standalone
+    </id>
+    <version>
+       2.0.0
+    </version>
+    <authors>
+       Robert Moore, Matthew Davies
+    </authors>
+    <description>
+      Provides an NHibernate driver that uses the Microsoft Transient Fault Handling library to allow for reliable SQL Azure connections.
+      Unlike NHibernate.SqlAzure, this library doesn't come with TransientFaultHandling IL-merged - instead it's a NuGet dependency.
+    </description>
+    <releaseNotes>
+      Please see https://github.com/MRCollective/NHibernate.SqlAzure/releases for release notes and https://github.com/MRCollective/NHibernate.SqlAzure/blob/master/BREAKING_CHANGES.md for any breaking changes.
+    </releaseNotes>
+    <projectUrl>
+      https://github.com/MRCollective/NHibernate.SqlAzure
+    </projectUrl>
+    <licenseUrl>
+      https://github.com/MRCollective/NHibernate.SqlAzure/blob/master/LICENSE
+    </licenseUrl>
+    <iconUrl>
+      https://raw.github.com/MRCollective/NHibernate.SqlAzure/master/logo.png
+    </iconUrl>
+    <tags>
+       nhibernate, azure, sql, sql azure, transient
+    </tags>
+    <language>
+       en-US 
+    </language>
+    <dependencies>
+      <dependency id="NHibernate" version="[5.0, 5.1)" />
+      <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0" />
+      <dependency id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0" />
+    </dependencies>
+  </metadata>
+  <files>
+     <file src="bin\Release\NHibernate.SqlAzure.dll" target="lib\NET45" />
+     <file src="bin\Release\NHibernate.SqlAzure.pdb" target="lib\NET45" />
+     <file src="bin\Release\NHibernate.SqlAzure.XML" target="lib\NET45" />
+     <file src="..\NHibernate.SqlAzure\**\*.cs" exclude="..\NHibernate.SqlAzure\obj\**\*.*" target="src" />
+  </files>
+</package>

--- a/NHibernate5.SqlAzure/NHibernate5.SqlAzure.Standalone.nuspec
+++ b/NHibernate5.SqlAzure/NHibernate5.SqlAzure.Standalone.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>
-       NHibernate4.SqlAzure.Standalone
+       NHibernate5.SqlAzure.Standalone
     </id>
     <version>
        2.0.0

--- a/NHibernate5.SqlAzure/NHibernate5.SqlAzure.csproj
+++ b/NHibernate5.SqlAzure/NHibernate5.SqlAzure.csproj
@@ -1,0 +1,116 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{895B6F59-B5BE-4796-847D-C3FF2C7EED66}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NHibernate5.SqlAzure</RootNamespace>
+    <AssemblyName>NHibernate5.SqlAzure</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f, processorArchitecture=MSIL">
+      <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Iesi.Collections.4.0.2\lib\net461\Iesi.Collections.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\EnterpriseLibrary.TransientFaultHandling.Data.6.0.1304.1\lib\NET45\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data.dll</HintPath>
+    </Reference>
+    <Reference Include="NHibernate, Version=5.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.5.0.3\lib\net461\NHibernate.dll</HintPath>
+    </Reference>
+    <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="Remotion.Linq.EagerFetching, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Remotion.Linq.EagerFetching.2.1.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\NHibernate.SqlAzure\DefaultReliableSql2008ClientDriver.cs">
+      <Link>DefaultReliableSql2008ClientDriver.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure\ReliableAdoNetTransactionFactory.cs">
+      <Link>ReliableAdoNetTransactionFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure\ReliableAdoTransaction.cs">
+      <Link>ReliableAdoTransaction.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure\ReliableSqlClientBatchingBatcherFactory.cs">
+      <Link>ReliableSqlClientBatchingBatcherFactory.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure\ReliableSqlDbConnection.cs">
+      <Link>ReliableSqlDbConnection.cs</Link>
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure\RetryStrategies\SqlAzureTransientErrorDetectionStrategy.cs">
+      <Link>SqlAzureTransientErrorDetectionStrategy.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure\RetryStrategies\SqlAzureTransientErrorDetectionStrategyWithTimeouts.cs">
+      <Link>SqlAzureTransientErrorDetectionStrategyWithTimeouts.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure\SqlAzureClientDriver.cs">
+      <Link>SqlAzureClientDriver.cs</Link>
+    </Compile>
+    <Compile Include="..\NHibernate.SqlAzure\SqlAzureClientDriverWithTimeoutRetries.cs">
+      <Link>SqlAzureClientDriverWithTimeoutRetries.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReliableAdoNetWithDistributedTransactionFactory.cs" />
+    <Compile Include="ReliableSql2008ClientDriver.cs" />
+    <Compile Include="ReliableSqlClientBatchingBatcher.cs" />
+    <Compile Include="ReliableSqlCommand.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="NHibernate5.SqlAzure.nuspec">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="NHibernate5.SqlAzure.Standalone.nuspec">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>mkdir "$(TargetDir)Combined"
+"$(ProjectDir)..\packages\ilmerge.2.14.1208\tools\ILMerge.exe" /v4 /target:library "$(TargetPath)" "$(TargetDir)Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll" "$(TargetDir)Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data.dll" /out:"$(TargetDir)Combined\NHibernate.SqlAzure.dll"
+copy "$(TargetDir)NHibernate.SqlAzure.XML" "$(TargetDir)Combined\NHibernate.SqlAzure.XML"</PostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/NHibernate5.SqlAzure/NHibernate5.SqlAzure.csproj
+++ b/NHibernate5.SqlAzure/NHibernate5.SqlAzure.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{895B6F59-B5BE-4796-847D-C3FF2C7EED66}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>NHibernate5.SqlAzure</RootNamespace>
-    <AssemblyName>NHibernate5.SqlAzure</AssemblyName>
+    <RootNamespace>NHibernate.SqlAzure</RootNamespace>
+    <AssemblyName>NHibernate.SqlAzure</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>

--- a/NHibernate5.SqlAzure/NHibernate5.SqlAzure.csproj
+++ b/NHibernate5.SqlAzure/NHibernate5.SqlAzure.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\NHibernate.SqlAzure.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,6 +29,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\NHibernate.SqlAzure.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f, processorArchitecture=MSIL">
@@ -96,7 +98,9 @@
     <Compile Include="ReliableAdoNetWithDistributedTransactionFactory.cs" />
     <Compile Include="ReliableSql2008ClientDriver.cs" />
     <Compile Include="ReliableSqlClientBatchingBatcher.cs" />
-    <Compile Include="ReliableSqlCommand.cs" />
+    <Compile Include="ReliableSqlCommand.cs">
+      <SubType>Component</SubType>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="NHibernate5.SqlAzure.nuspec">

--- a/NHibernate5.SqlAzure/NHibernate5.SqlAzure.csproj
+++ b/NHibernate5.SqlAzure/NHibernate5.SqlAzure.csproj
@@ -110,7 +110,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>mkdir "$(TargetDir)Combined"
-"$(ProjectDir)..\packages\ilmerge.2.14.1208\tools\ILMerge.exe" /v4 /target:library "$(TargetPath)" "$(TargetDir)Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll" "$(TargetDir)Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data.dll" /out:"$(TargetDir)Combined\NHibernate.SqlAzure.dll"
+"$(ProjectDir)..\packages\ilmerge.2.14.1208\tools\ILMerge.exe" /log:log.txt /v4 /target:library "$(TargetPath)" "$(TargetDir)Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll" "$(TargetDir)Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data.dll" /out:"$(TargetDir)Combined\NHibernate.SqlAzure.dll"
 copy "$(TargetDir)NHibernate.SqlAzure.XML" "$(TargetDir)Combined\NHibernate.SqlAzure.XML"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/NHibernate5.SqlAzure/NHibernate5.SqlAzure.nuspec
+++ b/NHibernate5.SqlAzure/NHibernate5.SqlAzure.nuspec
@@ -1,0 +1,45 @@
+﻿<?xml version='1.0' encoding='UTF-8'?> 
+<package>
+  <metadata>
+    <id>
+       NHibernate4.SqlAzure
+    </id>
+    <version>
+       2.0.0
+    </version>
+    <authors>
+       Robert Moore, Matthew Davies
+    </authors>
+    <description>
+      Provides an NHibernate driver that uses the Microsoft Transient Fault Handling library to allow for reliable SQL Azure connections.
+      This package has the Microsoft Transient Fault Handling library IL-merged into it; for a version that doesn't see the NHibernate.SqlAzure.Standalone package.
+    </description>
+    <releaseNotes>
+      Please see https://github.com/MRCollective/NHibernate.SqlAzure/releases for release notes and https://github.com/MRCollective/NHibernate.SqlAzure/blob/master/BREAKING_CHANGES.md for any breaking changes.
+    </releaseNotes>
+    <projectUrl>
+      https://github.com/MRCollective/NHibernate.SqlAzure
+    </projectUrl>
+    <licenseUrl>
+      https://github.com/MRCollective/NHibernate.SqlAzure/blob/master/LICENSE
+    </licenseUrl>
+    <iconUrl>
+      https://raw.github.com/MRCollective/NHibernate.SqlAzure/master/logo.png
+    </iconUrl>
+    <tags>
+       nhibernate, azure, sql, sql azure, transient
+    </tags>
+    <language>
+       en-US 
+    </language>
+    <dependencies>
+      <dependency id="NHibernate" version="[5.0, 5.1)" />
+    </dependencies>
+  </metadata>
+  <files>
+     <file src="bin\Release\Combined\NHibernate.SqlAzure.dll" target="lib\NET45" />
+     <file src="bin\Release\Combined\NHibernate.SqlAzure.pdb" target="lib\NET45" />
+     <file src="bin\Release\Combined\NHibernate.SqlAzure.XML" target="lib\NET45" />
+     <file src="..\NHibernate.SqlAzure\**\*.cs" exclude="..\NHibernate.SqlAzure\obj\**\*.*" target="src" />
+  </files>
+</package>

--- a/NHibernate5.SqlAzure/NHibernate5.SqlAzure.nuspec
+++ b/NHibernate5.SqlAzure/NHibernate5.SqlAzure.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>
-       NHibernate4.SqlAzure
+       NHibernate5.SqlAzure
     </id>
     <version>
        2.0.0

--- a/NHibernate5.SqlAzure/Properties/AssemblyInfo.cs
+++ b/NHibernate5.SqlAzure/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NHibernate5.SqlAzure")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NHibernate5.SqlAzure")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("895b6f59-b5be-4796-847d-c3ff2c7eed66")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/NHibernate5.SqlAzure/ReliableAdoNetWithDistributedTransactionFactory.cs
+++ b/NHibernate5.SqlAzure/ReliableAdoNetWithDistributedTransactionFactory.cs
@@ -1,0 +1,36 @@
+﻿using NHibernate.Engine;
+using NHibernate.Engine.Transaction;
+using NHibernate.Transaction;
+
+namespace NHibernate.SqlAzure
+{
+    /// <summary>
+    /// An NHibernate transaction factory that provides retry logic for transient errors when executing transactions.
+    /// It is aware of Distributed Transactions.
+    /// </summary>
+    /// <remarks>
+    /// Requires the connection to be a <see cref="ReliableSqlDbConnection"/>
+    /// </remarks>
+    public class ReliableAdoNetWithDistributedTransactionFactory : AdoNetWithSystemTransactionFactory, ITransactionFactory
+    {
+        public new ITransaction CreateTransaction(ISessionImplementor session)
+        {
+            return new ReliableAdoTransaction(session);
+        }
+
+        /// <summary>
+        /// Executes some work in isolation.
+        /// </summary>
+        /// <param name="session">The NHibernate session</param>
+        /// <param name="work">The work to execute</param>
+        /// <param name="transacted">Whether or not to wrap the work in a transaction</param>
+        public new void ExecuteWorkInIsolation(ISessionImplementor session, IIsolatedWork work, bool transacted)
+        {
+            var connection = (ReliableSqlDbConnection) session.Connection;
+
+            ReliableAdoTransaction.ExecuteWithRetry(connection,
+                () => base.ExecuteWorkInIsolation(session, work, transacted)
+            );
+        }
+    }
+}

--- a/NHibernate5.SqlAzure/ReliableSql2008ClientDriver.cs
+++ b/NHibernate5.SqlAzure/ReliableSql2008ClientDriver.cs
@@ -1,0 +1,53 @@
+﻿using System.Data;
+using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using NHibernate.AdoNet;
+using NHibernate.Driver;
+using Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling;
+
+namespace NHibernate.SqlAzure
+{
+	using System.Data.Common;
+
+	/// <summary>
+    /// Abstract base class that enables the creation of an NHibernate client driver that extends the Sql 2008 driver,
+    /// but adds in transient fault handling retry logic via <see cref="ReliableSqlConnection"/>.
+    /// </summary>
+    public abstract class ReliableSql2008ClientDriver : Sql2008ClientDriver, IEmbeddedBatcherFactoryProvider
+    {
+        /// <summary>
+        /// Provides a <see cref="ReliableSqlConnection"/> instance to use for connections.
+        /// </summary>
+        /// <returns>A reliable connection</returns>
+        protected abstract ReliableSqlConnection CreateReliableConnection();
+
+        /// <summary>
+        /// Creates an uninitialized <see cref="T:System.Data.DbConnection"/> object for the SqlClientDriver.
+        /// </summary>
+        /// <value>
+        /// An unitialized <see cref="T:System.Data.SqlClient.SqlConnection"/> object.
+        /// </value>
+        public override DbConnection CreateConnection()
+        {
+            return new ReliableSqlDbConnection(CreateReliableConnection());
+        }
+
+        /// <summary>
+        /// Creates an uninitialized <see cref="T:System.Data.DbCommand"/> object for the SqlClientDriver.
+        /// </summary>
+        /// <value>
+        /// An unitialized <see cref="T:System.Data.SqlClient.SqlCommand"/> object.
+        /// </value>
+        public override DbCommand CreateCommand()
+        {
+            return new ReliableSqlCommand();
+        }
+
+        /// <summary>
+        /// Returns the class to use for the Batcher Factory.
+        /// </summary>
+        public System.Type BatcherFactoryClass
+        {
+            get { return typeof(ReliableSqlClientBatchingBatcherFactory); }
+        }
+    }
+}

--- a/NHibernate5.SqlAzure/ReliableSqlClientBatchingBatcher.cs
+++ b/NHibernate5.SqlAzure/ReliableSqlClientBatchingBatcher.cs
@@ -1,0 +1,175 @@
+﻿// Parts of this file were copied from NHibernate.AdoNet.SqlClientBatchingBatcherFactory, but modified to use ReliableSqlDbConnection
+// The #regions indicate the copied code
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Reflection;
+using System.Text;
+using NHibernate.AdoNet;
+using NHibernate.AdoNet.Util;
+using NHibernate.Exceptions;
+
+namespace NHibernate.SqlAzure
+{
+    /// <summary>
+    /// Exposes <see cref="SqlClientBatchingBatcher"/> functionality when a <see cref="ReliableSqlDbConnection"/>
+    /// connection is being used.
+    /// </summary>
+    public class ReliableSqlClientBatchingBatcher : SqlClientBatchingBatcher
+    {
+        #region Impersonate private fields in base class
+        private readonly ConnectionManager _connectionManager;
+        private readonly FieldInfo _totalExpectedRowsAffectedField = typeof(SqlClientBatchingBatcher)
+            .GetField("_totalExpectedRowsAffected", BindingFlags.NonPublic | BindingFlags.Instance);
+        private readonly FieldInfo _currentBatchField = typeof (SqlClientBatchingBatcher)
+            .GetField("_currentBatch", BindingFlags.NonPublic | BindingFlags.Instance);
+        private readonly FieldInfo _currentBatchCommandsLogField = typeof(SqlClientBatchingBatcher)
+            .GetField("_currentBatchCommandsLog", BindingFlags.NonPublic | BindingFlags.Instance);
+        private readonly MethodInfo _createConfiguredBatchMethod = typeof (SqlClientBatchingBatcher)
+            .GetMethod("CreateConfiguredBatch", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        // ReSharper disable InconsistentNaming
+        private int _totalExpectedRowsAffected
+        {
+            get { return (int)_totalExpectedRowsAffectedField.GetValue(this); }
+            set { _totalExpectedRowsAffectedField.SetValue(this, value); }
+        }
+        private SqlClientSqlCommandSet _currentBatch
+        {
+            get { return (SqlClientSqlCommandSet)_currentBatchField.GetValue(this); }
+            set { _currentBatchField.SetValue(this, value); }
+        }
+        private StringBuilder _currentBatchCommandsLog
+        {
+            get { return (StringBuilder) _currentBatchCommandsLogField.GetValue(this); }
+            set { _currentBatchCommandsLogField.SetValue(this, value); }
+        }
+        private int _batchSize
+        {
+            get { return BatchSize; }
+        }
+        // ReSharper restore InconsistentNaming
+
+        private SqlClientSqlCommandSet CreateConfiguredBatch()
+        {
+            return (SqlClientSqlCommandSet)_createConfiguredBatchMethod.Invoke(this, null);
+        }
+        
+        public ReliableSqlClientBatchingBatcher(ConnectionManager connectionManager, IInterceptor interceptor)
+            : base(connectionManager, interceptor)
+        {
+            _connectionManager = connectionManager;
+        }
+        #endregion
+
+        public override void AddToBatch(IExpectation expectation)
+        {
+            #region NHibernate code
+            _totalExpectedRowsAffected += expectation.ExpectedRowCount;
+            DbCommand batchUpdate = CurrentCommand;
+            Driver.AdjustCommand(batchUpdate);
+            string lineWithParameters = null;
+            var sqlStatementLogger = Factory.Settings.SqlStatementLogger;
+            if (sqlStatementLogger.IsDebugEnabled || Log.IsDebugEnabled)
+            {
+                lineWithParameters = sqlStatementLogger.GetCommandLineWithParameters(batchUpdate);
+                var formatStyle = sqlStatementLogger.DetermineActualStyle(FormatStyle.Basic);
+                lineWithParameters = formatStyle.Formatter.Format(lineWithParameters);
+                _currentBatchCommandsLog.Append("command ")
+                    .Append(_currentBatch.CountOfCommands)
+                    .Append(":")
+                    .AppendLine(lineWithParameters);
+            }
+            if (Log.IsDebugEnabled)
+            {
+                Log.Debug("Adding to batch:" + lineWithParameters);
+            }
+            #endregion
+            _currentBatch.Append((System.Data.SqlClient.SqlCommand)(ReliableSqlCommand)batchUpdate);
+            #region NHibernate code
+            if (_currentBatch.CountOfCommands >= _batchSize)
+            {
+                ExecuteBatchWithTiming(batchUpdate);
+            }
+            #endregion
+        }
+
+        // Need this method call in this class rather than the base class to ensure Prepare is called... if only it was virtual :(
+        protected void ExecuteBatch(IDbCommand ps)
+        {
+            #region NHibernate code
+            Log.DebugFormat("Executing batch");
+            CheckReaders();
+            Prepare(_currentBatch.BatchCommand);
+            if (Factory.Settings.SqlStatementLogger.IsDebugEnabled)
+            {
+                Factory.Settings.SqlStatementLogger.LogBatchCommand(_currentBatchCommandsLog.ToString());
+                _currentBatchCommandsLog = new StringBuilder().AppendLine("Batch commands:");
+            }
+
+            int rowsAffected;
+            try
+            {
+                rowsAffected = _currentBatch.ExecuteNonQuery();
+            }
+            catch (DbException e)
+            {
+                throw ADOExceptionHelper.Convert(Factory.SQLExceptionConverter, e, "could not execute batch command.");
+            }
+
+            Expectations.VerifyOutcomeBatched(_totalExpectedRowsAffected, rowsAffected);
+
+            _currentBatch.Dispose();
+            _totalExpectedRowsAffected = 0;
+            _currentBatch = CreateConfiguredBatch();
+            #endregion
+        }
+
+        /// <summary>
+        /// Prepares the <see cref="DbCommand"/> for execution in the database.
+        /// </summary>
+        /// <remarks>
+        /// This takes care of hooking the <see cref="DbCommand"/> up to an <see cref="DbConnection"/>
+        /// and <see cref="DbTransaction"/> if one exists.  It will call <c>Prepare</c> if the Driver
+        /// supports preparing commands.
+        /// </remarks>
+        protected new void Prepare(DbCommand cmd)
+        {
+            try
+            {
+                var sessionConnection = (ReliableSqlDbConnection)_connectionManager.GetConnection();
+
+                #region NHibernate code
+                if (cmd.Connection != null)
+                {
+                    // make sure the commands connection is the same as the Sessions connection
+                    // these can be different when the session is disconnected and then reconnected
+                    if (cmd.Connection != sessionConnection)
+                    {
+                        cmd.Connection = (System.Data.SqlClient.SqlConnection) sessionConnection;
+                    }
+                }
+                else
+                {
+                    cmd.Connection = (System.Data.SqlClient.SqlConnection) sessionConnection;
+                }
+
+                _connectionManager.Transaction.Enlist(cmd);
+                Driver.PrepareCommand(cmd);
+                #endregion
+            }
+            catch (InvalidOperationException ioe)
+            {
+                #region NHibernate code
+                throw new ADOException("While preparing " + cmd.CommandText + " an error occurred", ioe);
+                #endregion
+            }
+        }
+
+        protected override void DoExecuteBatch(DbCommand ps)
+        {
+            var connection = (ReliableSqlDbConnection)_connectionManager.GetConnection();
+            ReliableAdoTransaction.ExecuteWithRetry(connection, () => ExecuteBatch(ps));
+        }
+    }
+}

--- a/NHibernate5.SqlAzure/ReliableSqlCommand.cs
+++ b/NHibernate5.SqlAzure/ReliableSqlCommand.cs
@@ -1,0 +1,141 @@
+using System.Data;
+using System.Data.SqlClient;
+using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling;
+
+namespace NHibernate.SqlAzure
+{
+	using System.Data.Common;
+
+	/// <summary>
+    /// An <see cref="IDbCommand"/> implementation that wraps a <see cref="SqlCommand"/> object such that any
+    /// queries that are executed are executed via a <see cref="ReliableSqlConnection"/>.
+    /// </summary>
+    /// <remarks>
+    /// Note: For this to work it requires that the Connection property be set with a <see cref="ReliableSqlConnection"/> object.
+    /// </remarks>
+    public class ReliableSqlCommand : DbCommand
+    {
+        /// <summary>
+        /// The underlying <see cref="SqlCommand"/> being proxied.
+        /// </summary>
+        public System.Data.SqlClient.SqlCommand Current { get; private set; }
+
+        /// <summary>
+        /// The <see cref="ReliableSqlConnection"/> that has been assigned to the command via the Connection property.
+        /// </summary>
+        public ReliableSqlConnection ReliableConnection { get; set; }
+
+        /// <summary>
+        /// Constructs a <see cref="ReliableSqlCommand"/>.
+        /// </summary>
+        public ReliableSqlCommand()
+        {
+            Current = new System.Data.SqlClient.SqlCommand();
+        }
+
+        /// <summary>
+        /// Explicit type-casting between a <see cref="ReliableSqlCommand"/> and a <see cref="SqlCommand"/>.
+        /// </summary>
+        /// <param name="command">The <see cref="ReliableSqlCommand"/> being casted</param>
+        /// <returns>The underlying <see cref="SqlCommand"/> being proxied.</returns>
+        public static explicit operator System.Data.SqlClient.SqlCommand(ReliableSqlCommand command)
+        {
+            return command.Current;
+        }
+
+		/// <summary>
+		/// Returns the underlying <see cref="SqlConnection"/> and expects a <see cref="ReliableSqlConnection"/> when being set.
+		/// </summary>
+		protected override DbConnection DbConnection
+		{
+            get { return Current.Connection; }
+            set
+            {
+                ReliableConnection = ((ReliableSqlDbConnection)value).ReliableConnection;
+                Current.Connection = ReliableConnection.Current;
+            }
+        }
+		
+
+	    #region Wrapping code
+      
+
+        public override  void Prepare()
+        {
+            Current.Prepare();
+        }
+
+        public override void Cancel()
+        {
+            Current.Cancel();
+        }
+
+        protected override DbParameter CreateDbParameter()
+        {
+            return Current.CreateParameter();
+        }
+
+        public override int ExecuteNonQuery()
+        {
+            return ReliableConnection.ExecuteCommand(Current);
+        }
+
+        public IDataReader ExecuteReader()
+        {
+            return ReliableConnection.ExecuteCommand<IDataReader>(Current);
+        }
+
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+        {
+            return ReliableConnection.ExecuteCommand<DbDataReader>(Current, behavior);
+        }
+
+        public override object ExecuteScalar()
+        {
+            return ReliableConnection.ExecuteCommand<int>(Current);
+        }
+        
+        protected override DbTransaction DbTransaction
+        {
+            get { return Current.Transaction; }
+            set { Current.Transaction = (SqlTransaction)value; }
+        }
+
+	    public override bool DesignTimeVisible
+	    {
+		    get { return Current.DesignTimeVisible; }
+		    set { Current.DesignTimeVisible = value; }
+	    }
+
+	    public override string CommandText
+        {
+            get { return Current.CommandText; }
+            set { Current.CommandText = value; }
+        }
+
+        public override int CommandTimeout
+        {
+            get { return Current.CommandTimeout; }
+            set { Current.CommandTimeout = value; }
+        }
+
+        public override CommandType CommandType
+        {
+            get { return Current.CommandType; }
+            set { Current.CommandType = value; }
+        }
+
+        protected override DbParameterCollection DbParameterCollection
+		{
+            get { return Current.Parameters; }
+        }
+
+        public override UpdateRowSource UpdatedRowSource
+        {
+            get { return Current.UpdatedRowSource; }
+            set { Current.UpdatedRowSource = value; }
+        }
+        #endregion
+    }
+}

--- a/NHibernate5.SqlAzure/packages.config
+++ b/NHibernate5.SqlAzure/packages.config
@@ -3,6 +3,7 @@
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
   <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net461" />
   <package id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0.1304.1" targetFramework="net461" />
+  <package id="ILMerge" version="2.14.1208" targetFramework="net461" />
   <package id="NHibernate" version="5.0.3" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />

--- a/NHibernate5.SqlAzure/packages.config
+++ b/NHibernate5.SqlAzure/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
+  <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net461" />
+  <package id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0.1304.1" targetFramework="net461" />
+  <package id="NHibernate" version="5.0.3" targetFramework="net461" />
+  <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
+  <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />
+</packages>

--- a/packages/repositories.config
+++ b/packages/repositories.config
@@ -4,4 +4,6 @@
   <repository path="..\NHibernate.SqlAzure\packages.config" />
   <repository path="..\NHibernate4.SqlAzure.Tests\packages.config" />
   <repository path="..\NHibernate4.SqlAzure\packages.config" />
+  <repository path="..\NHibernate5.SqlAzure.Tests\packages.config" />
+  <repository path="..\NHibernate5.SqlAzure\packages.config" />
 </repositories>


### PR DESCRIPTION
This update provides support for NHibernate 5 which included some breaking changes that needed to be addressed in this library. This work is meant to address and close issue #25 and was greatly guided by the work @RogerKratz did in the Teleopti fork.