### PR TITLE
Specify the precise version of dependencies to avoid compiler warning NU1603

### DIFF
--- a/NHibernate.SqlAzure/NHibernate.SqlAzure.Standalone.nuspec
+++ b/NHibernate.SqlAzure/NHibernate.SqlAzure.Standalone.nuspec
@@ -34,8 +34,8 @@
     </language>
     <dependencies>
       <dependency id="NHibernate" version="3.3.3.4000" />
-      <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0" />
-      <dependency id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0" />
+      <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" />
+      <dependency id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0.1304.1" />
     </dependencies>
   </metadata>
   <files>

--- a/NHibernate4.SqlAzure/NHibernate4.SqlAzure.Standalone.nuspec
+++ b/NHibernate4.SqlAzure/NHibernate4.SqlAzure.Standalone.nuspec
@@ -34,8 +34,8 @@
     </language>
     <dependencies>
       <dependency id="NHibernate" version="[4.1, 4.2)" />
-      <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0" />
-      <dependency id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0" />
+      <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" />
+      <dependency id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0.1304.1" />
     </dependencies>
   </metadata>
   <files>

--- a/NHibernate5.SqlAzure/NHibernate5.SqlAzure.Standalone.nuspec
+++ b/NHibernate5.SqlAzure/NHibernate5.SqlAzure.Standalone.nuspec
@@ -34,8 +34,8 @@
     </language>
     <dependencies>
       <dependency id="NHibernate" version="[5.0, 5.1)" />
-      <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0" />
-      <dependency id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0" />
+      <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" />
+      <dependency id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0.1304.1" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Explanation of why a package author should specify an existing lower bound version of a dependency: https://github.com/NuGet/Home/issues/5764

Currently a non existing version is indicated:
`      <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0" />`
`      <dependency id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0" />`

but it should be 
`      <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" />`
`      <dependency id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0.1304.1" />`

