### PR TITLE
Update to NH 5.2

### DIFF
--- a/NHibernate.SqlAzure.Tests/App.Release.config
+++ b/NHibernate.SqlAzure.Tests/App.Release.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <appSettings>
-    <add key="SqlServerServiceName" value="MSSQL$SQL2014" xdt:Locator="Match(key)" xdt:Transform="SetAttributes" />
+    <add key="SqlServerServiceName" value="MSSQL$SQL2019" xdt:Locator="Match(key)" xdt:Transform="SetAttributes" />
   </appSettings>
   <connectionStrings>
-    <add name="PooledDatabase" connectionString="Server=(local)\SQL2014;Database=master;User ID=sa;Password=Password12!;Initial Catalog=NHibernateSqlAzureTests" xdt:Locator="Match(name)" xdt:Transform="SetAttributes" />
-    <add name="NonPooledDatabase" connectionString="Server=(local)\SQL2014;Database=master;User ID=sa;Password=Password12!;Initial Catalog=NHibernateSqlAzureTests;Pooling=false" xdt:Locator="Match(name)" xdt:Transform="SetAttributes" />
+    <add name="PooledDatabase" connectionString="Server=(local)\SQL2019;Database=master;User ID=sa;Password=Password12!;Initial Catalog=NHibernateSqlAzureTests" xdt:Locator="Match(name)" xdt:Transform="SetAttributes" />
+    <add name="NonPooledDatabase" connectionString="Server=(local)\SQL2019;Database=master;User ID=sa;Password=Password12!;Initial Catalog=NHibernateSqlAzureTests;Pooling=false" xdt:Locator="Match(name)" xdt:Transform="SetAttributes" />
   </connectionStrings>
 </configuration>

--- a/NHibernate.SqlAzure.Tests/Config/NHibernateTestBase.cs
+++ b/NHibernate.SqlAzure.Tests/Config/NHibernateTestBase.cs
@@ -98,19 +98,18 @@ namespace NHibernate.SqlAzure.Tests.Config
             var tokenSource = new CancellationTokenSource();
             Task.Run(() =>
             {
-                while (!tokenSource.IsCancellationRequested)
-                {
-                    _serviceController.Refresh();
-                    if (_serviceController.Status == ServiceControllerStatus.Running)
-                        _serviceController.Pause();
-                    _serviceController.WaitForStatus(ServiceControllerStatus.Paused);
+                Thread.Sleep(100);
 
-                    _serviceController.Refresh();
-                    _serviceController.Continue();
-                    _serviceController.WaitForStatus(ServiceControllerStatus.Running);
+                _serviceController.Refresh();
+                if (_serviceController.Status == ServiceControllerStatus.Running)
+                    _serviceController.Pause();
+                _serviceController.WaitForStatus(ServiceControllerStatus.Paused);
 
-                    Thread.Sleep(20);
-                }
+                Thread.Sleep(50);
+
+                _serviceController.Refresh();
+                _serviceController.Continue();
+                _serviceController.WaitForStatus(ServiceControllerStatus.Running);
             }, tokenSource.Token);
             return new CancellableTask(tokenSource);
         }

--- a/NHibernate.SqlAzure.Tests/Config/NHibernateTestBase.cs
+++ b/NHibernate.SqlAzure.Tests/Config/NHibernateTestBase.cs
@@ -98,22 +98,29 @@ namespace NHibernate.SqlAzure.Tests.Config
             var tokenSource = new CancellationTokenSource();
             Task.Run(() =>
             {
-                Thread.Sleep(100);
+                // tests run for about 5 seconds, 
+                // lets wait for 1 second and then pause for 3 seconds, this will assure a retry and a retry with backoff will happen
+
+                Thread.Sleep(1000);
 
                 _serviceController.Refresh();
                 if (_serviceController.Status == ServiceControllerStatus.Running)
                     _serviceController.Pause();
                 _serviceController.WaitForStatus(ServiceControllerStatus.Paused);
 
-                Thread.Sleep(50);
+                Console.WriteLine(DateTime.Now.ToString("s:fff") + " SQLServer paused");
+                Thread.Sleep(3000);
 
                 _serviceController.Refresh();
                 _serviceController.Continue();
                 _serviceController.WaitForStatus(ServiceControllerStatus.Running);
+                Console.WriteLine(DateTime.Now.ToString("s:fff") + " SQLServer continued");
+
             }, tokenSource.Token);
+
             return new CancellableTask(tokenSource);
         }
-        
+
         protected class CancellableTask : IDisposable
         {
             private readonly CancellationTokenSource _tokenSource;

--- a/NHibernate.SqlAzure.Tests/ConnectionTests.cs
+++ b/NHibernate.SqlAzure.Tests/ConnectionTests.cs
@@ -34,12 +34,12 @@ namespace NHibernate.SqlAzure.Tests
         {
             using (TemporarilyShutdownSqlServerExpress())
             {
-                for (var i = 0; i < 1000; i++)
+                for (var i = 0; i < 100; i++)
                 {
                     using (var session = CreateSession())
                     {
                         Assert.That(session.Connection.State == ConnectionState.Open);
-                        Thread.Sleep(1);
+                        Thread.Sleep(50);
                     }
                 }
             }

--- a/NHibernate.SqlAzure.Tests/SqlClientDriverTests.cs
+++ b/NHibernate.SqlAzure.Tests/SqlClientDriverTests.cs
@@ -36,7 +36,7 @@ namespace NHibernate.SqlAzure.Tests
         {
             using (TemporarilyShutdownSqlServerExpress())
             {
-                for (var i = 0; i < 20; i++)
+                for (var i = 0; i < 100; i++)
                 {
                     Insert_and_select_multiple_entities();
                     Thread.Sleep(50);
@@ -62,7 +62,7 @@ namespace NHibernate.SqlAzure.Tests
             {
                 using (TemporarilyShutdownSqlServerExpress())
                 {
-                    for (var i = 0; i < 1000; i++)
+                    for (var i = 0; i < 100; i++)
                     {
                         Insert_and_select_entity();
                         Thread.Sleep(50);

--- a/NHibernate.SqlAzure/NHibernate.SqlAzure.Standalone.nuspec
+++ b/NHibernate.SqlAzure/NHibernate.SqlAzure.Standalone.nuspec
@@ -34,8 +34,8 @@
     </language>
     <dependencies>
       <dependency id="NHibernate" version="3.3.3.4000" />
-      <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0" />
-      <dependency id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0" />
+      <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" />
+      <dependency id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0.1304.1" />
     </dependencies>
   </metadata>
   <files>

--- a/NHibernate4.SqlAzure.Tests/App.Release.config
+++ b/NHibernate4.SqlAzure.Tests/App.Release.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <appSettings>
-    <add key="SqlServerServiceName" value="MSSQL$SQL2014" xdt:Locator="Match(key)" xdt:Transform="SetAttributes" />
+    <add key="SqlServerServiceName" value="MSSQL$SQL2019" xdt:Locator="Match(key)" xdt:Transform="SetAttributes" />
   </appSettings>
   <connectionStrings>
-    <add name="PooledDatabase" connectionString="Server=(local)\SQL2014;Database=master;User ID=sa;Password=Password12!;Initial Catalog=NHibernateSqlAzureTests" xdt:Locator="Match(name)" xdt:Transform="SetAttributes" />
-    <add name="NonPooledDatabase" connectionString="Server=(local)\SQL2014;Database=master;User ID=sa;Password=Password12!;Initial Catalog=NHibernateSqlAzureTests;Pooling=false" xdt:Locator="Match(name)" xdt:Transform="SetAttributes" />
+    <add name="PooledDatabase" connectionString="Server=(local)\SQL2019;Database=master;User ID=sa;Password=Password12!;Initial Catalog=NHibernateSqlAzureTests" xdt:Locator="Match(name)" xdt:Transform="SetAttributes" />
+    <add name="NonPooledDatabase" connectionString="Server=(local)\SQL2019;Database=master;User ID=sa;Password=Password12!;Initial Catalog=NHibernateSqlAzureTests;Pooling=false" xdt:Locator="Match(name)" xdt:Transform="SetAttributes" />
   </connectionStrings>
 </configuration>

--- a/NHibernate4.SqlAzure/NHibernate4.SqlAzure.Standalone.nuspec
+++ b/NHibernate4.SqlAzure/NHibernate4.SqlAzure.Standalone.nuspec
@@ -34,8 +34,8 @@
     </language>
     <dependencies>
       <dependency id="NHibernate" version="[4.1, 4.2)" />
-      <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0" />
-      <dependency id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0" />
+      <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" />
+      <dependency id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0.1304.1" />
     </dependencies>
   </metadata>
   <files>

--- a/NHibernate5.SqlAzure.Tests/App.Release.config
+++ b/NHibernate5.SqlAzure.Tests/App.Release.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <appSettings>
-    <add key="SqlServerServiceName" value="MSSQL$SQL2014" xdt:Locator="Match(key)" xdt:Transform="SetAttributes" />
+    <add key="SqlServerServiceName" value="MSSQL$SQL2019" xdt:Locator="Match(key)" xdt:Transform="SetAttributes" />
   </appSettings>
   <connectionStrings>
-    <add name="PooledDatabase" connectionString="Server=(local)\SQL2014;Database=master;User ID=sa;Password=Password12!;Initial Catalog=NHibernateSqlAzureTests" xdt:Locator="Match(name)" xdt:Transform="SetAttributes" />
-    <add name="NonPooledDatabase" connectionString="Server=(local)\SQL2014;Database=master;User ID=sa;Password=Password12!;Initial Catalog=NHibernateSqlAzureTests;Pooling=false" xdt:Locator="Match(name)" xdt:Transform="SetAttributes" />
+    <add name="PooledDatabase" connectionString="Server=(local)\SQL2019;Database=master;User ID=sa;Password=Password12!;Initial Catalog=NHibernateSqlAzureTests" xdt:Locator="Match(name)" xdt:Transform="SetAttributes" />
+    <add name="NonPooledDatabase" connectionString="Server=(local)\SQL2019;Database=master;User ID=sa;Password=Password12!;Initial Catalog=NHibernateSqlAzureTests;Pooling=false" xdt:Locator="Match(name)" xdt:Transform="SetAttributes" />
   </connectionStrings>
 </configuration>

--- a/NHibernate5.SqlAzure.Tests/App.config
+++ b/NHibernate5.SqlAzure.Tests/App.config
@@ -14,7 +14,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/NHibernate5.SqlAzure.Tests/NHibernate5.SqlAzure.Tests.csproj
+++ b/NHibernate5.SqlAzure.Tests/NHibernate5.SqlAzure.Tests.csproj
@@ -56,8 +56,9 @@
       <HintPath>..\packages\NHibernateProfiler.4.0.4049\lib\net46\HibernatingRhinos.Profiler.Appender.dll</HintPath>
     </Reference>
     <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Iesi.Collections.4.0.2\lib\net461\Iesi.Collections.dll</HintPath>
+      <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>
     </Reference>
@@ -67,17 +68,17 @@
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=5.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\packages\NHibernate.5.0.3\lib\net461\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=5.2.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.5.2.3\lib\net461\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
-      <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>
+    <Reference Include="Remotion.Linq, Version=2.2.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Remotion.Linq.2.2.0\lib\net45\Remotion.Linq.dll</HintPath>
     </Reference>
-    <Reference Include="Remotion.Linq.EagerFetching, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
-      <HintPath>..\packages\Remotion.Linq.EagerFetching.2.1.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
+    <Reference Include="Remotion.Linq.EagerFetching, Version=2.2.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Remotion.Linq.EagerFetching.2.2.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/NHibernate5.SqlAzure.Tests/NHibernate5.SqlAzure.Tests.csproj
+++ b/NHibernate5.SqlAzure.Tests/NHibernate5.SqlAzure.Tests.csproj
@@ -52,8 +52,8 @@
     <Reference Include="FluentNHibernate, Version=2.0.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\FluentNHibernate.2.0.3.0\lib\net40\FluentNHibernate.dll</HintPath>
     </Reference>
-    <Reference Include="HibernatingRhinos.Profiler.Appender, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0774796e73ebf640, processorArchitecture=MSIL">
-      <HintPath>..\packages\NHibernateProfiler.4.0.4049\lib\net46\HibernatingRhinos.Profiler.Appender.dll</HintPath>
+    <Reference Include="HibernatingRhinos.Profiler.Appender, Version=5.0.0.0, Culture=neutral, PublicKeyToken=0774796e73ebf640, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernateProfiler.5.0.5044\lib\net46\HibernatingRhinos.Profiler.Appender.dll</HintPath>
     </Reference>
     <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
@@ -85,8 +85,8 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.4.1\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.ServiceProcess" />

--- a/NHibernate5.SqlAzure.Tests/packages.config
+++ b/NHibernate5.SqlAzure.Tests/packages.config
@@ -6,15 +6,16 @@
   <package id="FluentMigrator" version="1.1.2.1" targetFramework="net461" />
   <package id="FluentMigrator.Runner" version="1.1.1.26" targetFramework="net461" />
   <package id="FluentNHibernate" version="2.0.3.0" targetFramework="net461" />
-  <package id="Iesi.Collections" version="4.0.2" targetFramework="net461" />
+  <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="Microsoft.VisualStudio.SlowCheetah" version="3.0.61" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="NBuilder" version="3.0.1.1" targetFramework="net461" />
-  <package id="NHibernate" version="5.0.3" targetFramework="net461" />
+  <package id="NHibernate" version="5.2.3" targetFramework="net461" />
   <package id="NHibernateProfiler" version="4.0.4049" targetFramework="net461" />
   <package id="NUnit" version="2.6.2" targetFramework="net461" />
-  <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
-  <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />
+  <package id="NUnitTestAdapter" version="2.1.0" targetFramework="net461" />
+  <package id="Remotion.Linq" version="2.2.0" targetFramework="net461" />
+  <package id="Remotion.Linq.EagerFetching" version="2.2.0" targetFramework="net461" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net461" />
   <package id="WebActivator" version="1.4.4" targetFramework="net461" />
   <package id="WebActivatorEx" version="2.0.5" targetFramework="net461" />

--- a/NHibernate5.SqlAzure.Tests/packages.config
+++ b/NHibernate5.SqlAzure.Tests/packages.config
@@ -11,12 +11,12 @@
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="NBuilder" version="3.0.1.1" targetFramework="net461" />
   <package id="NHibernate" version="5.2.3" targetFramework="net461" />
-  <package id="NHibernateProfiler" version="4.0.4049" targetFramework="net461" />
+  <package id="NHibernateProfiler" version="5.0.5044" targetFramework="net461" />
   <package id="NUnit" version="2.6.2" targetFramework="net461" />
   <package id="NUnitTestAdapter" version="2.1.0" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.2.0" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.2.0" targetFramework="net461" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net461" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net461" />
   <package id="WebActivator" version="1.4.4" targetFramework="net461" />
   <package id="WebActivatorEx" version="2.0.5" targetFramework="net461" />
 </packages>

--- a/NHibernate5.SqlAzure/NHibernate5.SqlAzure.Standalone.nuspec
+++ b/NHibernate5.SqlAzure/NHibernate5.SqlAzure.Standalone.nuspec
@@ -34,8 +34,8 @@
     </language>
     <dependencies>
       <dependency id="NHibernate" version="[5.0, 5.1)" />
-      <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0" />
-      <dependency id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0" />
+      <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" />
+      <dependency id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0.1304.1" />
     </dependencies>
   </metadata>
   <files>

--- a/NHibernate5.SqlAzure/NHibernate5.SqlAzure.Standalone.nuspec
+++ b/NHibernate5.SqlAzure/NHibernate5.SqlAzure.Standalone.nuspec
@@ -33,7 +33,7 @@
        en-US 
     </language>
     <dependencies>
-      <dependency id="NHibernate" version="[5.0, 5.1)" />
+      <dependency id="NHibernate" version="[5.0, 5.3)" />
       <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" />
       <dependency id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0.1304.1" />
     </dependencies>

--- a/NHibernate5.SqlAzure/NHibernate5.SqlAzure.Standalone.nuspec
+++ b/NHibernate5.SqlAzure/NHibernate5.SqlAzure.Standalone.nuspec
@@ -33,7 +33,7 @@
        en-US 
     </language>
     <dependencies>
-      <dependency id="NHibernate" version="[5.0, 5.3)" />
+      <dependency id="NHibernate" version="[5.1, 5.3)" />
       <dependency id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" />
       <dependency id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0.1304.1" />
     </dependencies>

--- a/NHibernate5.SqlAzure/NHibernate5.SqlAzure.csproj
+++ b/NHibernate5.SqlAzure/NHibernate5.SqlAzure.csproj
@@ -36,7 +36,7 @@
       <HintPath>..\packages\Antlr3.Runtime.3.5.1\lib\net40-client\Antlr3.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="Iesi.Collections, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Iesi.Collections.4.0.2\lib\net461\Iesi.Collections.dll</HintPath>
+      <HintPath>..\packages\Iesi.Collections.4.0.4\lib\net461\Iesi.Collections.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\EnterpriseLibrary.TransientFaultHandling.6.0.1304.0\lib\portable-net45+win+wp8\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.dll</HintPath>
@@ -44,14 +44,14 @@
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\EnterpriseLibrary.TransientFaultHandling.Data.6.0.1304.1\lib\NET45\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=5.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\packages\NHibernate.5.0.3\lib\net461\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=5.2.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <HintPath>..\packages\NHibernate.5.2.3\lib\net461\NHibernate.dll</HintPath>
     </Reference>
-    <Reference Include="Remotion.Linq, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
-      <HintPath>..\packages\Remotion.Linq.2.1.2\lib\net45\Remotion.Linq.dll</HintPath>
+    <Reference Include="Remotion.Linq, Version=2.2.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Remotion.Linq.2.2.0\lib\net45\Remotion.Linq.dll</HintPath>
     </Reference>
-    <Reference Include="Remotion.Linq.EagerFetching, Version=2.1.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
-      <HintPath>..\packages\Remotion.Linq.EagerFetching.2.1.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
+    <Reference Include="Remotion.Linq.EagerFetching, Version=2.2.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
+      <HintPath>..\packages\Remotion.Linq.EagerFetching.2.2.0\lib\net45\Remotion.Linq.EagerFetching.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/NHibernate5.SqlAzure/NHibernate5.SqlAzure.nuspec
+++ b/NHibernate5.SqlAzure/NHibernate5.SqlAzure.nuspec
@@ -33,7 +33,7 @@
        en-US 
     </language>
     <dependencies>
-      <dependency id="NHibernate" version="[5.0, 5.1)" />
+      <dependency id="NHibernate" version="[5.0, 5.3)" />
     </dependencies>
   </metadata>
   <files>

--- a/NHibernate5.SqlAzure/NHibernate5.SqlAzure.nuspec
+++ b/NHibernate5.SqlAzure/NHibernate5.SqlAzure.nuspec
@@ -33,7 +33,7 @@
        en-US 
     </language>
     <dependencies>
-      <dependency id="NHibernate" version="[5.0, 5.3)" />
+      <dependency id="NHibernate" version="[5.1, 5.3)" />
     </dependencies>
   </metadata>
   <files>

--- a/NHibernate5.SqlAzure/ReliableSqlClientBatchingBatcher.cs
+++ b/NHibernate5.SqlAzure/ReliableSqlClientBatchingBatcher.cs
@@ -70,7 +70,7 @@ namespace NHibernate.SqlAzure
             Driver.AdjustCommand(batchUpdate);
             string lineWithParameters = null;
             var sqlStatementLogger = Factory.Settings.SqlStatementLogger;
-            if (sqlStatementLogger.IsDebugEnabled || Log.IsDebugEnabled)
+            if (sqlStatementLogger.IsDebugEnabled || Log.IsDebugEnabled())
             {
                 lineWithParameters = sqlStatementLogger.GetCommandLineWithParameters(batchUpdate);
                 var formatStyle = sqlStatementLogger.DetermineActualStyle(FormatStyle.Basic);
@@ -80,7 +80,7 @@ namespace NHibernate.SqlAzure
                     .Append(":")
                     .AppendLine(lineWithParameters);
             }
-            if (Log.IsDebugEnabled)
+            if (Log.IsDebugEnabled())
             {
                 Log.Debug("Adding to batch:" + lineWithParameters);
             }
@@ -98,7 +98,7 @@ namespace NHibernate.SqlAzure
         protected void ExecuteBatch(IDbCommand ps)
         {
             #region NHibernate code
-            Log.DebugFormat("Executing batch");
+            Log.Debug("Executing batch");
             CheckReaders();
             Prepare(_currentBatch.BatchCommand);
             if (Factory.Settings.SqlStatementLogger.IsDebugEnabled)

--- a/NHibernate5.SqlAzure/packages.config
+++ b/NHibernate5.SqlAzure/packages.config
@@ -3,8 +3,9 @@
   <package id="Antlr3.Runtime" version="3.5.1" targetFramework="net461" />
   <package id="EnterpriseLibrary.TransientFaultHandling" version="6.0.1304.0" targetFramework="net461" />
   <package id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0.1304.1" targetFramework="net461" />
+  <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="ILMerge" version="2.14.1208" targetFramework="net461" />
-  <package id="NHibernate" version="5.0.3" targetFramework="net461" />
-  <package id="Remotion.Linq" version="2.1.2" targetFramework="net461" />
-  <package id="Remotion.Linq.EagerFetching" version="2.1.0" targetFramework="net461" />
+  <package id="NHibernate" version="5.2.3" targetFramework="net461" />
+  <package id="Remotion.Linq" version="2.2.0" targetFramework="net461" />
+  <package id="Remotion.Linq.EagerFetching" version="2.2.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Fixes [#28](https://github.com/MRCollective/NHibernate.SqlAzure/issues/28)

All test pass.

The only changes done were using the refactored logging interface of NH 5.1 and later. Unfortunately this is not backwards compatible.

Please use this PR instead of [PR#30](https://github.com/MRCollective/NHibernate.SqlAzure/pull/30) as PR#30 was made against my master branch.