### PR TITLE
Add needed overrides to ReliableSqlClientBatchingBatcher for (at least some of) the new async methods added to SqlClientBatchingBatcher

### DIFF
--- a/NHibernate5.SqlAzure.Tests/NHibernate5.SqlAzure.Tests.csproj
+++ b/NHibernate5.SqlAzure.Tests/NHibernate5.SqlAzure.Tests.csproj
@@ -68,8 +68,9 @@
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=5.2.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\packages\NHibernate.5.2.3\lib\net461\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=5.3.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
+      <HintPath>..\packages\NHibernate.5.3.9\lib\net461\NHibernate.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.2.12296, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.2\lib\nunit.framework.dll</HintPath>

--- a/NHibernate5.SqlAzure.Tests/packages.config
+++ b/NHibernate5.SqlAzure.Tests/packages.config
@@ -10,7 +10,7 @@
   <package id="Microsoft.VisualStudio.SlowCheetah" version="3.0.61" targetFramework="net461" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net461" />
   <package id="NBuilder" version="3.0.1.1" targetFramework="net461" />
-  <package id="NHibernate" version="5.2.3" targetFramework="net461" />
+  <package id="NHibernate" version="5.3.9" targetFramework="net461" />
   <package id="NHibernateProfiler" version="5.0.5044" targetFramework="net461" />
   <package id="NUnit" version="2.6.2" targetFramework="net461" />
   <package id="NUnitTestAdapter" version="2.1.0" targetFramework="net461" />

--- a/NHibernate5.SqlAzure/NHibernate5.SqlAzure.csproj
+++ b/NHibernate5.SqlAzure/NHibernate5.SqlAzure.csproj
@@ -44,8 +44,9 @@
     <Reference Include="Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\EnterpriseLibrary.TransientFaultHandling.Data.6.0.1304.1\lib\NET45\Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.Data.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate, Version=5.2.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
-      <HintPath>..\packages\NHibernate.5.2.3\lib\net461\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=5.3.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
+      <HintPath>..\packages\NHibernate.5.3.9\lib\net461\NHibernate.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Remotion.Linq, Version=2.2.0.0, Culture=neutral, PublicKeyToken=fee00910d6e5f53b, processorArchitecture=MSIL">
       <HintPath>..\packages\Remotion.Linq.2.2.0\lib\net45\Remotion.Linq.dll</HintPath>

--- a/NHibernate5.SqlAzure/packages.config
+++ b/NHibernate5.SqlAzure/packages.config
@@ -5,7 +5,7 @@
   <package id="EnterpriseLibrary.TransientFaultHandling.Data" version="6.0.1304.1" targetFramework="net461" />
   <package id="Iesi.Collections" version="4.0.4" targetFramework="net461" />
   <package id="ILMerge" version="2.14.1208" targetFramework="net461" />
-  <package id="NHibernate" version="5.2.3" targetFramework="net461" />
+  <package id="NHibernate" version="5.3.9" targetFramework="net461" />
   <package id="Remotion.Linq" version="2.2.0" targetFramework="net461" />
   <package id="Remotion.Linq.EagerFetching" version="2.2.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Updated project to NHibernate v5.3.9 and added _some_ missing async overrides in `ReliableSqlClientBatchingBatcher` for new async methods added by NHibernate in `SqlClientBatchingBatcher`.

(NOTE: Did not perform a full analysis for other possibly missing overrides -- just added and verified expected behavior for the ones needed for our project).